### PR TITLE
Avoid reference copy when struct has nested map and/or slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+
+# Created by https://www.gitignore.io/api/go,jetbrains+all,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=go,jetbrains+all,visualstudiocode
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.gitignore.io/api/go,jetbrains+all,visualstudiocode

--- a/copier.go
+++ b/copier.go
@@ -6,13 +6,13 @@ import (
 	"reflect"
 )
 
-// Copy copy things
 func Copy(toValue interface{}, fromValue interface{}) (err error) {
 	var (
 		isSlice bool
 		amount  = 1
 		from    = indirect(reflect.ValueOf(fromValue))
 		to      = indirect(reflect.ValueOf(toValue))
+		//opts    = createOptions(flags)
 	)
 
 	if !to.CanAddr() {
@@ -24,14 +24,14 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 		return
 	}
 
+	fromType := indirectType(from.Type())
+	toType := indirectType(to.Type())
+
 	// Just set it if possible to assign
-	if from.Type().AssignableTo(to.Type()) {
+	if fromType.Kind() != reflect.Struct && from.Type().AssignableTo(to.Type()) {
 		to.Set(from)
 		return
 	}
-
-	fromType := indirectType(from.Type())
-	toType := indirectType(to.Type())
 
 	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
 		return
@@ -57,71 +57,86 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 
 			// dest
 			dest = indirect(reflect.New(toType).Elem())
+
 		} else {
 			source = indirect(from)
 			dest = indirect(to)
 		}
 
-		// Copy from field to field or method
-		for _, field := range deepFields(fromType) {
-			name := field.Name
+		copyFromFieldToFieldOrMethod(fromType, source, dest)
 
-			if fromField := source.FieldByName(name); fromField.IsValid() {
-				// has field
-				if toField := dest.FieldByName(name); toField.IsValid() {
-					if toField.CanSet() {
-						if !set(toField, fromField) {
-							if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
-								return err
-							}
-						}
-					}
-				} else {
-					// try to set to method
-					var toMethod reflect.Value
-					if dest.CanAddr() {
-						toMethod = dest.Addr().MethodByName(name)
-					} else {
-						toMethod = dest.MethodByName(name)
-					}
-
-					if toMethod.IsValid() && toMethod.Type().NumIn() == 1 && fromField.Type().AssignableTo(toMethod.Type().In(0)) {
-						toMethod.Call([]reflect.Value{fromField})
-					}
-				}
-			}
-		}
-
-		// Copy from method to field
-		for _, field := range deepFields(toType) {
-			name := field.Name
-
-			var fromMethod reflect.Value
-			if source.CanAddr() {
-				fromMethod = source.Addr().MethodByName(name)
-			} else {
-				fromMethod = source.MethodByName(name)
-			}
-
-			if fromMethod.IsValid() && fromMethod.Type().NumIn() == 0 && fromMethod.Type().NumOut() == 1 {
-				if toField := dest.FieldByName(name); toField.IsValid() && toField.CanSet() {
-					values := fromMethod.Call([]reflect.Value{})
-					if len(values) >= 1 {
-						set(toField, values[0])
-					}
-				}
-			}
-		}
+		copyFromMethodToField(toType, source, dest)
 
 		if isSlice {
-			if dest.Addr().Type().AssignableTo(to.Type().Elem()) {
-				to.Set(reflect.Append(to, dest.Addr()))
-			} else if dest.Type().AssignableTo(to.Type().Elem()) {
-				to.Set(reflect.Append(to, dest))
+			setSlice(dest, to)
+		}
+	}
+
+	return
+}
+
+func setSlice(dest reflect.Value, to reflect.Value) {
+	if dest.Addr().Type().AssignableTo(to.Type().Elem()) {
+		to.Set(reflect.Append(to, dest.Addr()))
+	} else if dest.Type().AssignableTo(to.Type().Elem()) {
+		to.Set(reflect.Append(to, dest))
+	}
+}
+
+func copyFromMethodToField(toType reflect.Type, source reflect.Value, dest reflect.Value) {
+	// Copy from method to field
+	for _, field := range deepFields(toType) {
+		name := field.Name
+
+		var fromMethod reflect.Value
+		if source.CanAddr() {
+			fromMethod = source.Addr().MethodByName(name)
+		} else {
+			fromMethod = source.MethodByName(name)
+		}
+
+		if fromMethod.IsValid() && fromMethod.Type().NumIn() == 0 && fromMethod.Type().NumOut() == 1 {
+			if toField := dest.FieldByName(name); toField.IsValid() && toField.CanSet() {
+				values := fromMethod.Call([]reflect.Value{})
+				if len(values) >= 1 {
+					set(toField, values[0])
+				}
 			}
 		}
 	}
-	return
+}
+
+func copyFromFieldToFieldOrMethod(fromType reflect.Type, source reflect.Value, dest reflect.Value) (err error) {
+	for _, field := range deepFields(fromType) {
+		name := field.Name
+
+		if fromField := source.FieldByName(name); fromField.IsValid() {
+			// has field
+			if toField := dest.FieldByName(name); toField.IsValid() {
+				if toField.CanSet() {
+					if !set(toField, fromField) {
+						if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
+							return err
+						}
+					}
+				}
+			} else {
+				// try to set to method
+				var toMethod reflect.Value
+				if dest.CanAddr() {
+					toMethod = dest.Addr().MethodByName(name)
+				} else {
+					toMethod = dest.MethodByName(name)
+				}
+
+				if toMethod.IsValid() && toMethod.Type().NumIn() == 1 && fromField.Type().AssignableTo(toMethod.Type().In(0)) {
+					toMethod.Call([]reflect.Value{fromField})
+				}
+			}
+		}
+	}
+
+	return err
 }
 
 func deepFields(reflectType reflect.Type) []reflect.StructField {
@@ -158,6 +173,14 @@ func indirectType(reflectType reflect.Type) reflect.Type {
 func set(to, from reflect.Value) bool {
 	if from.IsValid() {
 		if to.Kind() == reflect.Ptr {
+			// This won't stomp down on TO with a nil value. So if TO is already populated, not sure
+			// want expected behavior is (copy vs merge)
+			if (from.Kind() == reflect.Ptr || from.Kind() == reflect.Map || from.Kind() == reflect.Slice) && from.IsNil() {
+				return true // leave to as Nil
+			} else if from.Type().Comparable() && from.Interface() == reflect.Zero(from.Type()).Interface() {
+				return true // if from is zero valued, leave to pointer as nil
+			}
+
 			//set `to` to nil if from is nil
 			if from.Kind() == reflect.Ptr && from.IsNil() {
 				to.Set(reflect.Zero(to.Type()))
@@ -168,7 +191,11 @@ func set(to, from reflect.Value) bool {
 			to = to.Elem()
 		}
 
-		if from.Type().ConvertibleTo(to.Type()) {
+		if from.Kind() == reflect.Map && to.Kind() == reflect.Map {
+			return setNestedMap(to, from)
+		} else if from.Kind() == reflect.Slice && to.Kind() == reflect.Slice {
+			return setNestedSlice(to, from)
+		} else if from.Type().ConvertibleTo(to.Type()) {
 			to.Set(from.Convert(to.Type()))
 		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
 			err := scanner.Scan(from.Interface())
@@ -181,5 +208,67 @@ func set(to, from reflect.Value) bool {
 			return false
 		}
 	}
+	return true
+}
+
+func setNestedMap(toValue, fromValue reflect.Value) bool {
+	if toValue.Kind() != reflect.Map || fromValue.Kind() != reflect.Map {
+		return false
+	}
+
+	for _, e := range fromValue.MapKeys() {
+		v := fromValue.MapIndex(e)
+
+		newKey := reflect.New(e.Type())
+
+		if !set(newKey, e) {
+			return false
+		}
+
+		newValue := reflect.New(v.Type())
+
+		if !set(newValue, v) {
+			return false
+		}
+
+		if toValue.IsNil() {
+			mapType := reflect.MapOf(indirectType(newKey.Type()), indirectType(newValue.Type()))
+			mapValue := reflect.MakeMap(mapType)
+			toValue.Set(mapValue)
+		}
+
+		toValue.SetMapIndex(indirect(newKey), indirect(newValue))
+	}
+
+	return true
+}
+
+func setNestedSlice(toValue, fromValue reflect.Value) bool {
+	if toValue.Kind() != reflect.Slice || fromValue.Kind() != reflect.Slice {
+		return false
+	}
+
+	amount := fromValue.Len()
+
+	for i := 0; i < amount; i++ {
+		var dest, source reflect.Value
+
+		// source
+		source = indirect(fromValue.Index(i))
+
+		// dest
+		dest = indirect(reflect.New(indirectType(toValue.Type())).Elem())
+
+		if indirectType(source.Type()).Kind() != reflect.Struct && source.Type().AssignableTo(dest.Type()) {
+			dest.Set(source)
+		} else {
+			copyFromFieldToFieldOrMethod(indirectType(source.Type()), source, dest)
+
+			copyFromMethodToField(indirectType(dest.Type()), source, dest)
+		}
+
+		setSlice(dest, toValue)
+	}
+
 	return true
 }

--- a/copier_benchmark_test.go
+++ b/copier_benchmark_test.go
@@ -2,9 +2,8 @@ package copier_test
 
 import (
 	"encoding/json"
+	"github.com/eberson/copier"
 	"testing"
-
-	"github.com/jinzhu/copier"
 )
 
 func BenchmarkCopyStruct(b *testing.B) {

--- a/copier_different_type_test.go
+++ b/copier_different_type_test.go
@@ -1,9 +1,8 @@
 package copier_test
 
 import (
+	"github.com/eberson/copier"
 	"testing"
-
-	"github.com/jinzhu/copier"
 )
 
 type TypeStruct1 struct {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/eberson/copier
+
+go 1.12
+
+require (
+	github.com/google/go-cmp v0.2.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/stretchr/testify v1.3.0
+	gotest.tools v2.2.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=


### PR DESCRIPTION
When we have struct with slices or map inside it, copier make copy as reference of these elements. This change avoid that making a deep copy of these elements.